### PR TITLE
Fixing indention of error.py

### DIFF
--- a/ixnetwork_restpy/errors.py
+++ b/ixnetwork_restpy/errors.py
@@ -24,8 +24,8 @@ from requests import Response
 class IxNetworkError(Exception):
     """The base error class for all IxNetwork REST API errors"""
     def __init__(self, message, status_code=None):
-		self._message = message
-		self._status_code = status_code
+        self._message = message
+        self._status_code = status_code
 
     @property
     def message(self):


### PR DESCRIPTION
The indention of the error.py was using tabs.

  File "/usr/local/lib/python3.6/dist-packages/ixnetwork_restpy/testplatform/testplatform.py", line 24, in <module>
    from ixnetwork_restpy.base import Base
  File "/usr/local/lib/python3.6/dist-packages/ixnetwork_restpy/base.py", line 25, in <module>
    from ixnetwork_restpy.connection import Connection
  File "/usr/local/lib/python3.6/dist-packages/ixnetwork_restpy/connection.py", line 32, in <module>
    from ixnetwork_restpy.errors import *
  File "/usr/local/lib/python3.6/dist-packages/ixnetwork_restpy/errors.py", line 27
    self._message = message
                          ^
TabError: inconsistent use of tabs and spaces in indentation