### PR TITLE
Shortcuts for exact match and get single result

### DIFF
--- a/ixnetwork_restpy/base.py
+++ b/ixnetwork_restpy/base.py
@@ -437,6 +437,34 @@ class Base(object):
 
         return [x for x in device_ids if x != 0]
 
+    def find_exact(self, **kwargs):
+        """Get instances with the given values, using exact match instead of regex."""
+        new_kwargs = {}
+        for key, value in kwargs.items():
+            if isinstance(value, str):
+                new_kwargs[key] = f'^{re.escape(value)}$'
+            else:
+                new_kwargs[key] = value
+        return self.find(**new_kwargs)
+
+    def get(self, **kwargs):
+        """Get a single instance with exact match, raise an error if there is none or more than one."""
+        result = self.find_exact(**kwargs)
+        if len(result) == 0:
+            raise ValueError(f"No instance found with {kwargs}")
+        if len(result) > 1:
+            raise ValueError(f"More than one instance matches {kwargs}")
+        return result[0]
+
+    def get_regex(self, **kwargs):
+        """Get a single instance with regex match, raise an error if there is none or more than one."""
+        result = self.find(**kwargs)
+        if len(result) == 0:
+            raise ValueError(f"No instance found with {kwargs}")
+        if len(result) > 1:
+            raise ValueError(f"More than one instance matches {kwargs}")
+        return result[0]
+
     def info(self, message):
         """Add an INFO level message to the logger handlers
         """


### PR DESCRIPTION
The `find` method of the objects always matches using regexes, and it always returns 0 or more results.

I usually need to get a specific object (say port x, x being a variable), but it's easy to make mistakes like:
```
port = '1'
ixnetwork_restpy.Vport.find(Name=port)  # this will return port 1, but also 10, 11, etc
```

So I added a few methods which quote the regex and check the number of results.