### PR TITLE
Correction of api_key issue inside SessionAssitant

### DIFF
--- a/ixnetwork_restpy/assistants/sessions/sessionassistant.py
+++ b/ixnetwork_restpy/assistants/sessions/sessionassistant.py
@@ -70,7 +70,7 @@ class SessionAssistant(object):
             verify_cert=VerifyCertificates,
             trace=LogLevel)
         if ApiKey is not None:
-            testplatform.Authenticate = ApiKey
+            testplatform.ApiKey = ApiKey
         elif UserName is not None and Password is not None:
             testplatform.Authenticate(UserName, Password)
         session = None


### PR DESCRIPTION
Small correction inside __init__ of SessionAssitant
exemple of code correct by the patch : 
```
from ixnetwork_restpy import SessionAssistant
ip = "172.0.0.1"
user = "admin"
password = "admin
sa = SessionAssistant(ip, UserName=user, Password=password)
key = sa.TestPlatform.ApiKey
print(key)
sa2 = SessionAssistant(ip, ApiKey=key)
print(sa2.Session)
```
