### PR TITLE
fix a bug when updating stack field elements

### DIFF
--- a/ixnetwork_restpy/base.py
+++ b/ixnetwork_restpy/base.py
@@ -406,12 +406,7 @@ class Base(object):
                 for item in self:
                     item_dict = {}
                     item_dict.update(payload)
-                    last_href_segment = item.href.split("/")[-1]
-                    if last_href_segment.isdigit():
-                        href = "/".join(item.href.split("/")[:-1])
-                        item_dict["id"] = last_href_segment
-                    else:
-                        href = item.href
+                    href = item.href
                     if payload_dict.get(href, None) is None:
                         payload_dict[href] = [item_dict]
                     else:


### PR DESCRIPTION
Ixia Web Edition 9.20.2112.6

I try to run this sample code, when executing to this line:

https://github.com/OpenIxia/IxNetwork/blob/7623e05362c067df67c492dbbc156b4df0c52a7a/RestPy/SampleScripts/createTrafficItemAddPacketHeader.py#L114

It will fail to update the value and api server will return 400 with  `InstanceId is not a string`
the log shows it sends
```
PATCH https://my_ip:443/api/v1/sessions/14/ixnetwork/traffic/trafficItem/1/configElement/1/stack/1/field/ {"valueType": "increment", "id": "1"}
```
which seems wrong.

I delete these lines and **it works fine now**, now the PATCH request is:
```
PATCH https://my_ip:443/api/v1/sessions/14/ixnetwork/traffic/trafficItem/1/configElement/1/stack/1/field/1 {"valueType": "increment"}
```

**I'm enabling ixia automation script for my team, please help verify this bug. If it is expected, please help to provide a workaround, thanks!**