### PR TITLE
remove deprecated pkg_resources package

### DIFF
--- a/uhd_restpy/connection.py
+++ b/uhd_restpy/connection.py
@@ -26,7 +26,7 @@ import datetime
 import time
 import json
 import logging
-import pkg_resources
+from importlib.metadata import version
 from requests import Session, request, utils
 from requests.exceptions import ConnectTimeout
 from io import BufferedReader
@@ -109,7 +109,7 @@ class Connection(object):
             try:
                 logging.getLogger(__name__).info(
                     "using ixnetwork-restpy version %s"
-                    % pkg_resources.get_distribution("ixnetwork-restpy").version
+                    % version("ixnetwork-restpy")
                 )
             except Exception as e:
                 logging.getLogger(__name__).warning(


### PR DESCRIPTION
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    import pkg_resources
